### PR TITLE
support rails 3 and 4 (current rails master)

### DIFF
--- a/ammeter.gemspec
+++ b/ammeter.gemspec
@@ -9,20 +9,20 @@ Gem::Specification.new do |s|
   s.authors     = ["Alex Rothenberg"]
   s.email       = ["alex@alexrothenberg.com"]
   s.homepage    = ""
-  s.summary     = %q{Write specs for your Rails 3 generators}
-  s.description = %q{Write specs for your Rails 3 generators}
+  s.summary     = %q{Write specs for your Rails 3+ generators}
+  s.description = %q{Write specs for your Rails 3+ generators}
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_runtime_dependency 'railties',      '~> 3.0'
-  s.add_runtime_dependency 'activesupport', '~> 3.0'
-  s.add_runtime_dependency 'rspec',         '~> 2.2'
-  s.add_runtime_dependency 'rspec-rails',   '~> 2.2'
+  s.add_runtime_dependency 'railties',      '>= 3.0'
+  s.add_runtime_dependency 'activesupport', '>= 3.0'
+  s.add_runtime_dependency 'rspec',         '>= 2.2'
+  s.add_runtime_dependency 'rspec-rails',   '>= 2.2'
 
-  s.add_development_dependency 'rails',    '~> 3.1'
+  s.add_development_dependency 'rails',    '>= 3.1'
   s.add_development_dependency 'uglifier'
   s.add_development_dependency 'turn'
   s.add_development_dependency 'rake'
@@ -32,5 +32,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cucumber', '~> 0.10'
   s.add_development_dependency 'aruba',    '~> 0.3'
   s.add_development_dependency 'sqlite3',  '~> 1'
-  
 end


### PR DESCRIPTION
The version in Rails' master is now 4.0.0.beta, so I updated the gem spec to allow for that. Without this change, rspec-rails can't run its specs against Rails master.
