### PR TITLE
InstanceMethods are deprecated in Rails 3.2

### DIFF
--- a/lib/ammeter/rspec/generator/example/generator_example_group.rb
+++ b/lib/ammeter/rspec/generator/example/generator_example_group.rb
@@ -41,12 +41,10 @@ module Ammeter
           end
         end
 
-        module InstanceMethods
-          def invoke_task name
-            capture(:stdout) { generator.invoke_task(generator_class.all_tasks[name.to_s]) }
-          end
+        def invoke_task name
+          capture(:stdout) { generator.invoke_task(generator_class.all_tasks[name.to_s]) }
         end
-
+      
         included do
           delegate :generator, :run_generator, :destination, :arguments, :to => :'self.class'
           DELEGATED_METHODS.each do |method|


### PR DESCRIPTION
Remove deprecated InstanceMethods module when using AS::Concern. The usage of InstanceMethods module when using ActiveSupport::Concern was deprecated in Rails 3.2.
