### PR TITLE
Manually delegate prepare_destination due to changes in delegate for Rai...

### DIFF
--- a/lib/ammeter/rspec/generator/example/generator_example_group.rb
+++ b/lib/ammeter/rspec/generator/example/generator_example_group.rb
@@ -13,8 +13,7 @@ module Ammeter
         extend ActiveSupport::Concern
         include ::RSpec::Rails::RailsExampleGroup
 
-        DELEGATED_METHODS = [:capture, :prepare_destination,
-                             :destination_root, :current_path, :generator_class]
+        DELEGATED_METHODS = [:capture, :destination_root, :current_path, :generator_class]
         module ClassMethods
           mattr_accessor :test_unit_test_case_delegate
           delegate :default_arguments, :to => :'self.test_unit_test_case_delegate'
@@ -23,6 +22,10 @@ module Ammeter
           end
           delegate :destination, :arguments, :to => ::Rails::Generators::TestCase
 
+          def prepare_destination
+            self.test_unit_test_case_delegate.send :prepare_destination
+          end
+          
           def initialize_delegate
             self.test_unit_test_case_delegate = ::Rails::Generators::TestCase.new 'pending'
             self.test_unit_test_case_delegate.class.tests(describes)
@@ -50,6 +53,11 @@ module Ammeter
           DELEGATED_METHODS.each do |method|
             delegate method,  :to => :'self.class'
           end
+          
+          def prepare_destination
+            self.class.send :prepare_destination
+          end
+          
           ::Rails::Generators::TestCase.destination File.expand_path('ammeter', Dir.tmpdir)
           initialize_delegate
 


### PR DESCRIPTION
...ls 4 

Rails 4 (edge) changes delegate to no longer use send which means it can no longer be used to delegate to a protected method in another object.  Since prepare_destination is a protected method this change manually delegates.
