### PR TITLE
Only load_generators if we Rails is available

### DIFF
--- a/lib/ammeter/init.rb
+++ b/lib/ammeter/init.rb
@@ -1,4 +1,6 @@
 require 'ammeter/rspec/generator/example.rb'
 require 'ammeter/rspec/generator/matchers.rb'
 
-Rails.application.load_generators
+if Rails.respond_to?(:application) && Rails.application.respond_to?(:load_generators)
+  Rails.application.load_generators
+end


### PR DESCRIPTION
Hi @alexrothenberg,

0.2.6 broke HEAD on Draper. Draper does not include Rails as a dependency, I suspect that is a not-uncommon case.

The patch is not ideal, I would love to see something better :|
