### PR TITLE
Modify contain matcher to accept multiple patterns

### DIFF
--- a/lib/ammeter/rspec/generator/matchers/contain.rb
+++ b/lib/ammeter/rspec/generator/matchers/contain.rb
@@ -1,19 +1,46 @@
-RSpec::Matchers.define :contain do |expected_content|
-  match do |file_path|
-    @actual_contents = File.new(file_path).read
-    case expected_content
-      when String
-        @actual_contents.include? expected_content
-      when Regexp
-        @actual_contents =~ expected_content
+RSpec::Matchers.define :contain do |*expected_contents|
+  match_for_should do |file_path|
+    @actual_contents = File.read(file_path)
+    not_found_expectations.empty?
+  end
+
+  match_for_should_not do |file_path|
+    @actual_contents = File.read(file_path)
+    found_expectations.empty?
+  end
+
+  failure_message_for_should do |file_path|
+    "expected the file #{file_path} to contain " +
+      if expected_contents.many?
+        "#{expected_contents.map(&:inspect).to_sentence} but " +
+          "#{not_found_expectations.map(&:inspect).to_sentence} #{not_found_expectations.many? ? 'were' : 'was'} not found"
+      else
+        "#{expected_contents.first.inspect} but it contained #{@actual_contents.inspect}"
+      end
+  end
+
+  failure_message_for_should_not do |file_path|
+    "expected the file #{file_path} to not contain " +
+      if expected_contents.many?
+        "#{expected_contents.map(&:inspect).to_sentence} but " +
+          "#{found_expectations.map(&:inspect).to_sentence} #{found_expectations.many? ? 'were' : 'was'} found"
+      else
+        "#{expected_contents.first.inspect} but it did"
+      end
+  end
+
+  define_method :found_expectations do
+    @found_expectations ||= expected_contents.select do |expected_content|
+      case expected_content
+        when String
+          @actual_contents.include? expected_content
+        when Regexp
+          @actual_contents =~ expected_content
+      end
     end
   end
-  
-  failure_message_for_should do |file_path|
-    "expected the file #{file_path} to contain #{expected_content.inspect} but it contained #{@actual_contents.inspect}"
-  end
-  
-  failure_message_for_should_not do |file_path|
-    "expected the file #{file_path} to not contain #{expected_content.inspect} but it did"
+
+  define_method :not_found_expectations do
+    @not_found_expectations ||= expected_contents - found_expectations
   end
 end

--- a/spec/ammeter/rspec/generator/matchers/contain_spec.rb
+++ b/spec/ammeter/rspec/generator/matchers/contain_spec.rb
@@ -4,18 +4,19 @@ describe "contain" do
 
   context "when the file exists" do
     let(:contents) { "This file\ncontains\nthis text" }
-    let(:mock_file) { mock(:read=>contents) }
 
     subject { '/some/file/path' }
     before do
-      File.stub(:new).with('/some/file/path').and_return(mock_file)
+      File.stub(:read).with('/some/file/path').and_return(contents)
     end
     it { should contain "This file\ncontains\nthis text" }
     it { should contain "This file" }
     it { should contain "this text" }
     it { should contain /This file/ }
     it { should contain /this text/ }
+    it { should contain "contains", /this text/ }
     it { should_not contain /something not there/ }
+    it { should_not contain /this isn't at the contents/, /neither is this/ }
   end
 
   context "when the file is not there" do


### PR DESCRIPTION
Allow contain matcher to specify multiple patters/strings.
When using 'should' expect every pattern to be found, when not, notify exactly which weren't.
When using 'should_not' expect every pattern to not be found, if some are, notify exactly which.
