### PR TITLE
Require Rails first since rspec-rails use the Rails constant

### DIFF
--- a/lib/ammeter/init.rb
+++ b/lib/ammeter/init.rb
@@ -1,6 +1,6 @@
+require 'rails'
 require 'ammeter/rspec/generator/example.rb'
 require 'ammeter/rspec/generator/matchers.rb'
-require 'rails'
 
 if Rails.respond_to?(:application) && Rails.application.respond_to?(:load_generators)
   Rails.application.load_generators


### PR DESCRIPTION
Requiring `ammeter/init` directly fails[1] due to missing constant in rspec-rails[2]:

```
/usr/share/gems/gems/rspec-rails-2.14.0/lib/rspec/rails/example/rails_example_group.rb:10:in `<module:RailsExampleGroup>': uninitialized constant Rails::VERSION (NameError)
    from /usr/share/gems/gems/rspec-rails-2.14.0/lib/rspec/rails/example/rails_example_group.rb:7:in `<module:Rails>'
    from /usr/share/gems/gems/rspec-rails-2.14.0/lib/rspec/rails/example/rails_example_group.rb:6:in `<module:RSpec>'
    from /usr/share/gems/gems/rspec-rails-2.14.0/lib/rspec/rails/example/rails_example_group.rb:5:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/local/share/gems/gems/ammeter-0.2.9/lib/ammeter/rspec/generator/example/generator_example_group.rb:4:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/local/share/gems/gems/ammeter-0.2.9/lib/ammeter/rspec/generator/example.rb:2:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/local/share/gems/gems/ammeter-0.2.9/lib/ammeter/init.rb:1:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:116:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:116:in `rescue in require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:122:in `require'
    from test.rb:2:in `<main>'

```

Reversing the order fixes the issue.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1007631
[2] https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/example/rails_example_group.rb#L10
