### PR TITLE
fixed a bug when using should_not be_a_migration

### DIFF
--- a/lib/ammeter/rspec/generator/matchers/be_a_migration.rb
+++ b/lib/ammeter/rspec/generator/matchers/be_a_migration.rb
@@ -7,6 +7,6 @@ RSpec::Matchers.define :be_a_migration do
     else
       migration_file_path = Dir.glob("#{dirname}/[0-9]*_*.rb").grep(/\d+_#{file_name}$/).first
     end
-    File.exist?(migration_file_path)
+    migration_file_path && File.exist?(migration_file_path)
   end
 end

--- a/spec/ammeter/rspec/generator/matchers/be_a_migration_spec.rb
+++ b/spec/ammeter/rspec/generator/matchers/be_a_migration_spec.rb
@@ -5,19 +5,19 @@ describe "be_a_migration" do
   let(:migration_files) { ['db/migrate/20110504132601_create_posts.rb', 'db/migrate/20110520132601_create_users.rb'] }
 
   before do
-    allow(File).to receive(:exist?).and_return(false)
     migration_files.each do |migration_file|
       allow(File).to receive(:exist?).with(migration_file).and_return(true)
     end
-    allow(Dir).to receive(:glob).with('db/migrate/[0-9]*_*.rb').and_return(migration_files)
   end
   it 'should find for the migration file adding the filename timestamp for us' do
+    expect(Dir).to receive(:glob).with('db/migrate/[0-9]*_*.rb').and_return(migration_files)
     expect('db/migrate/create_users.rb').to be_a_migration
   end
   it 'should find for the migration file when we know the filename timestamp' do
     expect('db/migrate/20110504132601_create_posts.rb').to be_a_migration
   end
   it 'should know when a migration does not exist' do
+    expect(Dir).to receive(:glob).with('db/migrate/[0-9]*_*.rb').and_return([])
     expect('db/migrate/create_comments.rb').to_not be_a_migration
   end
 end


### PR DESCRIPTION
It will fail, if 'should_not be_a_migration' is used when a file does not exist. 
