### PR TITLE
Add have_method matcher

### DIFF
--- a/lib/ammeter/rspec/generator/matchers.rb
+++ b/lib/ammeter/rspec/generator/matchers.rb
@@ -1,3 +1,4 @@
 require 'ammeter/rspec/generator/matchers/be_a_migration'
 require 'ammeter/rspec/generator/matchers/contain'
 require 'ammeter/rspec/generator/matchers/exist'
+require 'ammeter/rspec/generator/matchers/have_method'

--- a/lib/ammeter/rspec/generator/matchers/have_method.rb
+++ b/lib/ammeter/rspec/generator/matchers/have_method.rb
@@ -1,0 +1,10 @@
+RSpec::Matchers.define :have_method do |method|
+  chain :containing do |content|
+    @method_content = content.strip
+  end
+
+  match do |file_path|
+    content = File.read(file_path)
+    content =~ /(\s+)def #{method}(\(.+\))?(.*?)\n\1end/m && (@method_content.nil? ? true : $3.include?(@method_content))
+  end
+end

--- a/spec/ammeter/rspec/generator/matchers/have_method_spec.rb
+++ b/spec/ammeter/rspec/generator/matchers/have_method_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'have_method' do
+  let(:contents) { "class SomeClass\n  def some_method\n    puts 'Hello world!'\n  end\nend" }
+
+  subject { '/some/file/path' }
+  before { allow(File).to receive(:read).with('/some/file/path').and_return(contents) }
+
+  it { is_expected.to have_method(:some_method) }
+  it { is_expected.to have_method(:some_method).containing("puts 'Hello world!'")}
+  it { is_expected.to_not have_method(:some_method).containing("puts 'Good bye cruel world!' ") }
+  it { is_expected.to_not have_method(:some_other_method) }
+end


### PR DESCRIPTION
This pull request creates a new matcher (have_method) based on Rails::Generators::Testing::Assertions.
I don't like the idea of regex-based introspection but I couldn't find any clean way to run .rb file in sandbox and work with a class from there (I will try to work on that later).

This matcher can be transformed into [composable matcher](http://myronmars.to/n/dev-blog/2014/01/new-in-rspec-3-composable-matchers) at later time.

(Travis build fails at the moment because this pull request is not based on #31 but on current master)
