### PR TITLE
Raise aruba timeout to 30 seconds

### DIFF
--- a/features/support/aruba_timeout.rb
+++ b/features/support/aruba_timeout.rb
@@ -5,10 +5,3 @@ Aruba.configure do |config|
     set_env('JAVA_OPTS', "-d32 #{ENV['JAVA_OPTS']}") # force jRuby to use client JVM for faster startup times
   end
 end if RUBY_PLATFORM == 'java'
-
-# MRI 1.8.7 does not define RUBY_ENGINE
-if defined?(RUBY_ENGINE) && %w(jruby rbx).include?(RUBY_ENGINE)
-  Before do
-    @aruba_timeout_seconds = 30
-  end
-end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,7 @@
 require 'aruba/cucumber'
 
 Before do
-  @aruba_timeout_seconds = 10
+  @aruba_timeout_seconds = 30
 end
 
 def aruba_path(file_or_dir, source_foldername)


### PR DESCRIPTION
Previous value doesn't seem to work anymore for Travis (makes build fail randomly)
