### PR TITLE
Fix NameError for Ammeter::OutputCapturer

### DIFF
--- a/lib/ammeter/rspec/generator/example/generator_example_group.rb
+++ b/lib/ammeter/rspec/generator/example/generator_example_group.rb
@@ -4,6 +4,7 @@ require 'rspec/rails/adapters'
 require 'rspec/rails/example/rails_example_group'
 require 'tmpdir'
 require 'fileutils'
+require 'ammeter/output_capturer'
 
 module Ammeter
   module RSpec


### PR DESCRIPTION
Failures:

      1) Scenic::Generators::ModelGenerator invokes the view generator
         Failure/Error: run_generator ["current_customer"]
         NameError:
           uninitialized constant Ammeter::RSpec::Rails::GeneratorExampleGroup::ClassMethods::OutputCapturer
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/ammeter-1.1.2/lib/ammeter/rspec/generator/example/generator_example_group.rb:47:in `run_generator'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/ammeter-1.1.2/lib/ammeter/rspec/generator/example/generator_example_group.rb:56:in `run_generator'
         # ./spec/generators/scenic/model/model_generator_spec.rb:14:in `block (2 levels) in <module:Generators>'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:151:in `instance_exec'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:151:in `block in run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:221:in `call'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:221:in `call'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-rails-3.1.0/lib/rspec/rails/adapters.rb:72:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:321:in `instance_exec'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:321:in `instance_exec'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/hooks.rb:380:in `execute_with'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/hooks.rb:446:in `block (2 levels) in run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:221:in `call'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:221:in `call'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/hooks.rb:447:in `run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/hooks.rb:500:in `run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:330:in `with_around_example_hooks'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example.rb:148:in `run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example_group.rb:500:in `block in run_examples'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example_group.rb:496:in `map'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example_group.rb:496:in `run_examples'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/example_group.rb:463:in `run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/runner.rb:111:in `block (2 levels) in run_specs'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/runner.rb:111:in `map'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/runner.rb:111:in `block in run_specs'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/reporter.rb:53:in `report'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/runner.rb:107:in `run_specs'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/runner.rb:85:in `run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/runner.rb:69:in `run'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/lib/rspec/core/runner.rb:37:in `invoke'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/gems/rspec-core-3.1.5/exe/rspec:4:in `<top (required)>'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/bin/rspec:23:in `load'
         # /Users/caleb/.rvm/gems/ruby-2.1.2@scenic/bin/rspec:23:in `<main>'

    Finished in 0.00705 seconds (files took 0.88302 seconds to load)
    1 example, 1 failure

    Failed examples:

    rspec ./spec/generators/scenic/model/model_generator_spec.rb:13 # Scenic::Generators::ModelGenerator invokes the view generator

    Randomized with seed 17228