### PR TITLE
Set the default subject in the module.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ else
   raise "rspec version #{rspec_version} is not supported"
 end
 
+gem "i18n", '< 0.7.0' if RUBY_VERSION < '1.9.3'
+
 # Specify your gem's dependencies in rspec-rails-generator-specs.gemspec
 gemspec
 

--- a/features/templates/generate_example_app.rb
+++ b/features/templates/generate_example_app.rb
@@ -14,6 +14,7 @@ else
   gem 'rspec',       rspec_version
 end
 
+gem "i18n", '< 0.7.0' if RUBY_VERSION < '1.9.3'
 gem 'ammeter', :path=>'../..'
 if defined?(Rails) && Rails::VERSION::STRING.to_f < 4
   # Execjs is causing problems on 1.8.7

--- a/lib/ammeter/rspec/generator/example/generator_example_group.rb
+++ b/lib/ammeter/rspec/generator/example/generator_example_group.rb
@@ -65,8 +65,6 @@ module Ammeter
           ::Rails::Generators::TestCase.destination File.expand_path('ammeter', Dir.tmpdir)
           initialize_delegate
 
-          subject { generator }
-
           before do
             self.class.initialize_delegate
             prepare_destination
@@ -85,6 +83,9 @@ module Ammeter
           migration_file = Dir.glob("#{File.dirname(file_path)}/[0-9]*_#{File.basename(file_path)}").first
           migration_file = "#{File.dirname(file_path)}/TIMESTAMP_#{File.basename(file_path)}" if migration_file.nil?
           migration_file
+        end
+        def subject
+          generator
         end
       end
     end


### PR DESCRIPTION
By setting the default subject with `included` is sets the `subject`
helper on the internal RSpec memoized helper modules. This causes
warnings when another top-level `subject` is defined by the spec author.

This removes using the RSpec memoized helper module and simply sets a
`subject` method delegate for `generator`. The generator is already
memoized by ammeter so we are not missing that feature from RSpec.