### PR TITLE
Unneeded shebang.

### DIFF
--- a/features/templates/my_rails_gem/Rakefile
+++ b/features/templates/my_rails_gem/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 require "bundler/gem_tasks"
 
 require 'rspec'

--- a/features/templates/my_railties_gem/Rakefile
+++ b/features/templates/my_railties_gem/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 require "bundler/gem_tasks"
 
 require 'rspec'


### PR DESCRIPTION
I found that shebang "#!/usr/bin/env rake" in ammeter template's Rakefile.
I think that if the shebang exists in the file, that means that file is executable.
But actually Rakefile is not used as executable.
So, in this case, we can remove the shebang "#!/usr/bin/env rake" in the Rakefile.

Could you check it?
Best,
Jun Aruga