### PR TITLE
Adding generator example helper to set response values for basic shell prompts

### DIFF
--- a/features/generator_with_shell_prompts_spec.feature
+++ b/features/generator_with_shell_prompts_spec.feature
@@ -1,0 +1,56 @@
+@example_app
+Feature: generator with shell prompts spec
+
+  Generator specs live in spec/generators. In order to access
+  the generator's methods you can call them on the "generator" object.
+
+  Background: A simple generator
+    Given a file named "lib/generators/awesome/lamest_generator.rb" with:
+      """
+      class LamestGenerator < Rails::Generators::NamedBase
+        source_root File.expand_path('../templates', __FILE__)
+        class_option :super, :type => :boolean, :default => false
+
+        def create_lamest
+          @lame = false 
+          @awesome = false
+          @user_name = ask("What is your name?")
+          if yes?("Are you the lamest?")
+            @lame = true
+          end
+          if yes?("Are you awesome?")
+            @awesome = true
+          end
+          template 'lamest.html.erb', File.join('public', name, "#{"super_" if options[:super]}lamest.html")
+        end
+      end
+      """
+    And a file named "lib/generators/awesome/templates/lamest.html.erb" with:
+      """
+      <%= @user_name %> <%= "is the lamest" if @lame %> and <%= "is not awesome!" if @awesome == false %>
+      """
+
+  Scenario: A spec that runs the entire generator
+    Given a file named "spec/generators/lamest_generator_spec.rb" with:
+      """
+      require "rails_helper"
+      require 'generators/awesome/lamest_generator'
+
+      describe LamestGenerator do
+        describe 'invoke' do
+          before do 
+            gen = generator %w(my_dir)
+            set_shell_prompt_responses(gen, { :ask => "Thomas", :yes? => [true, false] })
+            run_generator
+          end
+          describe 'public/my_dir/lamest.html' do
+            subject { file('public/my_dir/lamest.html') }
+            it { expect(subject).to exist }
+            it { expect(subject).to contain 'Thomas is the lamest and is not awesome!' }
+            it { expect(subject).to_not contain 'This text is not in the file' }
+          end
+        end
+      end
+      """
+    When I run `rake spec`
+    Then the output should contain "3 examples, 0 failures"

--- a/lib/ammeter/rspec/generator/example.rb
+++ b/lib/ammeter/rspec/generator/example.rb
@@ -9,7 +9,8 @@ RSpec::configure do |c|
 
   generator_path_regex = c.escaped_path(%w[spec generators])
   if RSpec::Core::Version::STRING >= '3'
-    c.include Ammeter::RSpec::Rails::GeneratorExampleHelpers
+    c.include Ammeter::RSpec::Rails::GeneratorExampleHelpers,
+      :type          => :generator
     c.include Ammeter::RSpec::Rails::GeneratorExampleGroup,
       :type          => :generator,
       :file_path     => lambda { |file_path, metadata|
@@ -17,7 +18,7 @@ RSpec::configure do |c|
       }
 
   else #rspec2
-    c.include Ammeter::RSpec::Rails::GeneratorExampleHelpers
+    c.include Ammeter::RSpec::Rails::GeneratorExampleHelpers, :type => :generator
     c.include Ammeter::RSpec::Rails::GeneratorExampleGroup, :type => :generator, :example_group => {
       :file_path => generator_path_regex
     }

--- a/lib/ammeter/rspec/generator/example.rb
+++ b/lib/ammeter/rspec/generator/example.rb
@@ -17,7 +17,7 @@ RSpec::configure do |c|
       }
 
   else #rspec2
-
+    c.include Ammeter::RSpec::Rails::GeneratorExampleHelpers
     c.include Ammeter::RSpec::Rails::GeneratorExampleGroup, :type => :generator, :example_group => {
       :file_path => generator_path_regex
     }

--- a/lib/ammeter/rspec/generator/example.rb
+++ b/lib/ammeter/rspec/generator/example.rb
@@ -1,5 +1,6 @@
 require 'rspec/core'
 require 'ammeter/rspec/generator/example/generator_example_group'
+require 'ammeter/rspec/generator/example/generator_example_helpers'
 
 RSpec::configure do |c|
   def c.escaped_path(*parts)
@@ -8,6 +9,7 @@ RSpec::configure do |c|
 
   generator_path_regex = c.escaped_path(%w[spec generators])
   if RSpec::Core::Version::STRING >= '3'
+    c.include Ammeter::RSpec::Rails::GeneratorExampleHelpers
     c.include Ammeter::RSpec::Rails::GeneratorExampleGroup,
       :type          => :generator,
       :file_path     => lambda { |file_path, metadata|

--- a/lib/ammeter/rspec/generator/example/generator_example_helpers.rb
+++ b/lib/ammeter/rspec/generator/example/generator_example_helpers.rb
@@ -1,0 +1,29 @@
+require 'rails/generators'
+require 'active_support/core_ext'
+
+module Ammeter
+  module RSpec
+    module Rails
+      # Delegates to Rails::Generators::TestCase to work with RSpec.
+      module GeneratorExampleHelpers
+
+        # Sets return values for basic shell commands (ex. ask, yes?, no?). 
+        # Does this by mocking return values using RSpec's `and_return` method
+        # 
+        # ===== Parameters =====
+        # Generator w/ @shell attribute
+        # Hash { command_name: input_value, ask: "Testing", yes?: true }
+        # The values for each element in the hash can be set as an array as well.
+        # This will allow for different return values upon each call.
+        # 
+        # ex. set_shell_prompt_responses(generator, { yes?: [true, false] })
+        # would respond with true to the first yes? call, but false to the second
+        def set_shell_prompt_responses(generator, command_args={})
+          command_args.each do |k,v|
+            allow(generator.shell).to receive(k.to_sym).and_return(*v)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ammeter/rspec/generator/example/generator_example_helpers_spec.rb
+++ b/spec/ammeter/rspec/generator/example/generator_example_helpers_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+module Ammeter::RSpec::Rails
+  describe GeneratorExampleHelpers do
+    let(:generator) { Generator.new }
+
+    it "mocks return value of ask to response" do
+      set_shell_prompt_responses(generator, { :ask => "response" })
+      expect(generator.shell.ask).to eq("response")
+    end
+    context "arguments contain multiple shell commands" do
+      it "mocks return values response for ask and true for yes?" do
+        set_shell_prompt_responses(generator, { :ask => "response", :yes? => true })
+        expect(generator.shell.ask).to eq("response")
+        expect(generator.shell.yes?).to be true
+      end
+    end
+    context "argument shell command contains an array" do
+      it "mocks sequential return values response1 and response2" do
+        set_shell_prompt_responses(generator, { :ask => ["response1", "response2"] })
+        expect(generator.shell.ask).to eq("response1")
+        expect(generator.shell.ask).to eq("response2")
+      end
+    end
+  end
+end

--- a/spec/ammeter/rspec/generator/example/generator_example_helpers_spec.rb
+++ b/spec/ammeter/rspec/generator/example/generator_example_helpers_spec.rb
@@ -2,7 +2,8 @@ require "spec_helper"
 
 module Ammeter::RSpec::Rails
   describe GeneratorExampleHelpers do
-    let(:generator) { Generator.new }
+    include GeneratorExampleHelpers
+    let(:generator) { MockGenerator.new }
 
     it "mocks return value of ask to response" do
       set_shell_prompt_responses(generator, { :ask => "response" })

--- a/spec/support/mock_generator.rb
+++ b/spec/support/mock_generator.rb
@@ -1,0 +1,12 @@
+# Used in generator_example_helpers_spec.rb
+# set_shell_prompt_responses requires a generator w/ a shell
+# as an argument. This class defines that generator w/ a shell.
+require_relative 'mock_shell'
+
+class Generator
+  attr_accessor :shell
+
+  def initialize
+    @shell = Shell.new
+  end
+end

--- a/spec/support/mock_generator.rb
+++ b/spec/support/mock_generator.rb
@@ -1,12 +1,10 @@
 # Used in generator_example_helpers_spec.rb
 # set_shell_prompt_responses requires a generator w/ a shell
 # as an argument. This class defines that generator w/ a shell.
-require_relative 'mock_shell'
-
-class Generator
+class MockGenerator
   attr_accessor :shell
 
   def initialize
-    @shell = Shell.new
+    @shell = Object.new
   end
 end

--- a/spec/support/mock_shell.rb
+++ b/spec/support/mock_shell.rb
@@ -1,0 +1,5 @@
+# Used in generator_example_helpers_spec.rb
+# set_shell_prompt_responses requires a generator w/ a shell
+# as an argument. This class defines shell that belongs to a Generator.
+class Shell
+end

--- a/spec/support/mock_shell.rb
+++ b/spec/support/mock_shell.rb
@@ -1,5 +1,0 @@
-# Used in generator_example_helpers_spec.rb
-# set_shell_prompt_responses requires a generator w/ a shell
-# as an argument. This class defines shell that belongs to a Generator.
-class Shell
-end


### PR DESCRIPTION
I've been using ammeter over the past couple of weeks to write tests for a rails generator that I have. The generator contains one command, but when running this command it prompts the user for multiple forms of input, using basic shell methods (ex. ask, yes? no?), throughout the process. I realized that running my generator with ammeter would fail if I didn't respond to these shell prompts, so I decided to mock the return values for these different shell methods. This actually worked quite nicely and sparked me to add a helper to ammeter that will set or stub out the return values for the different basic shell methods that can be used within generators, that require some user response/input. 

I'm not quite sure if ammeter already has a nice way of handling this, but this PR includes a GeneratorExampleHelpers module that defines a method `set_shell_prompt_responses`, that essentially sets the return values for the different basic shell methods that are often used within Rails generators. It accomplishes this by using RSpec's method stubbing strategy that defines return values for when a given object receives a specific method. I think this is pretty nice to have, because it allows the user to reduce the number of similar method stub calls (ex. `allow(blah).to_receive(:blah_method).and_return("blah")`) that they might possibly need in their test scenarios for their generator. I think it also helps abstract the inner-workings of the generator away from the tester, so that they can better focus on testing the behavior of their generator.

That being said, this PR has been rebased on the most recent master, and it also has RSpec tests and Cucumber features to validate this feature. All tests are passing locally.

Hopefully this is something you all think will be useful! And sorry for the long explanation!

Feel free to let me know if there's anything else you need from me.

-Thomas Baird 