### PR TITLE
Fix NameError if only 'railties' (not 'rails') gem is installed

### DIFF
--- a/lib/ammeter/init.rb
+++ b/lib/ammeter/init.rb
@@ -3,7 +3,7 @@ require 'rspec/rails'
 if RSpec::Core::Version::STRING < '3'
   require 'ammeter/rspec/rspec_2_compatibility'  # if rspec2
 end
-require 'rails'
+require 'rails/engine'
 require 'ammeter/output_capturer.rb'
 require 'ammeter/rspec/generator/example.rb'
 require 'ammeter/rspec/generator/matchers.rb'


### PR DESCRIPTION
If a project depends on 'ammeter' and 'railties', `require 'ammeter/init'` fails with

```
 NameError: uninitialized constant ActionView::Template::Handlers::ERB::ENCODING_FLAG
```

We need only 'rails/engine', so let's require it explicitly.
