### PR TITLE
Support RSpec 4

### DIFF
--- a/lib/ammeter/rspec/generator/example.rb
+++ b/lib/ammeter/rspec/generator/example.rb
@@ -12,7 +12,8 @@ RSpec::configure do |c|
     c.include Ammeter::RSpec::Rails::GeneratorExampleHelpers,
       :type          => :generator
     c.include Ammeter::RSpec::Rails::GeneratorExampleGroup,
-      :type          => :generator,
+      :type          => :generator
+    c.include Ammeter::RSpec::Rails::GeneratorExampleGroup,
       :file_path     => lambda { |file_path, metadata|
         metadata[:type].nil? && generator_path_regex =~ file_path
       }

--- a/lib/ammeter/version.rb
+++ b/lib/ammeter/version.rb
@@ -1,3 +1,3 @@
 module Ammeter
-  VERSION = "1.1.4"
+  VERSION = "1.1.5"
 end


### PR DESCRIPTION
RSpec 4 has changed the semantic of multi-condition filtering.  To include a module to a group matching *any* of the conditions, the conditions should be separate statements.

See:
- https://github.com/rspec/rspec-core/issues/1821
- https://github.com/rspec/rspec-core/pull/2874
- example failure (`Ammeter::RSpec::Rails::GeneratorExampleGroup` that defines `destination` is not included) https://github.com/rspec/rspec-core/pull/2874/checks?check_run_id=1942170588