### PR TITLE
Deprecate the custom exist matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ describe Rspec::Generators::ModelGenerator, :type => :generator do
     describe 'the spec' do
       # file - gives you the absolute path where the generator will create the file
       subject { file('spec/models/posts_spec.rb') }
-      # is_expected_to exist - verifies the file exists
-      it { is_expected_to exist }
 
       # is_expected_to contain - verifies the file's contents
       it { is_expected_to contain /require 'spec_helper'/ }
@@ -82,7 +80,7 @@ describe Rspec::Generators::ModelGenerator, :type => :generator do
       subject { migration_file('db/migrate/create_posts.rb') }
 
       # is_expected_to be_a_migration - verifies the file exists with a migration timestamp as part of the filename
-      it { is_expected_to exist }
+      it { is_expected_to be_a_migration }
       it { is_expected_to contain /create_table/ }
     end
   end
@@ -91,7 +89,6 @@ end
 
 # Available matchers
 
-- `exist` - verifies the file exists
 - `contain` - verifies the file's contents
 - `be_a_migration` - verifies the file exists with a migration timestamp as part of the filename
 - `have_method` - verifies the file (or a class withing it) implements a method

--- a/lib/ammeter/rspec/generator/matchers/exist.rb
+++ b/lib/ammeter/rspec/generator/matchers/exist.rb
@@ -1,5 +1,11 @@
-RSpec::Matchers.define :exist do
+# DEPRECATED: use `expect(Pathname.new(path)).to exist` instead
+RSpec::Matchers.define :exist do |*expected|
   match do |file_path|
-    File.exist?(file_path)
+    if !(file_path.respond_to?(:exist?) || file_path.respond_to?(:exists?))
+      ActiveSupport::Deprecation.warn "The `exist` matcher overrides one built-in by RSpec; use `expect(Pathname.new(path)).to exist` instead"
+      File.exist?(file_path)
+    else
+      RSpec::Matchers::BuiltIn::Exist.new(*expected).matches?(file_path)
+    end
   end
 end

--- a/spec/ammeter/rspec/generator/matchers/exist_spec.rb
+++ b/spec/ammeter/rspec/generator/matchers/exist_spec.rb
@@ -5,9 +5,15 @@ describe "exist" do
     allow(File).to receive(:exist?).with('/some/file/path').and_return(true)
     expect('/some/file/path').to exist
   end
+
   it 'fails when the file does not exist' do
     allow(File).to receive(:exist?).with('/some/file/path').and_return(false)
     expect('/some/file/path').to_not exist
   end
 
+  it 'maintains default RSpec behavior' do
+    path = Pathname.new('/some/file/path')
+    allow(path).to receive(:exist?).and_return(true)
+    expect(path).to exist
+  end
 end

--- a/spec/ammeter/rspec/generator/matchers/exist_spec.rb
+++ b/spec/ammeter/rspec/generator/matchers/exist_spec.rb
@@ -11,9 +11,11 @@ describe "exist" do
     expect('/some/file/path').to_not exist
   end
 
-  it 'maintains default RSpec behavior' do
+  it 'maintains default RSpec behavior', :aggregate_failures do
     path = Pathname.new('/some/file/path')
     allow(path).to receive(:exist?).and_return(true)
     expect(path).to exist
+    allow(path).to receive(:exist?).and_return(false)
+    expect(path).not_to exist
   end
 end


### PR DESCRIPTION
Prefer the one built-in by RSpec instead. Fall back to the built-in matcher for default behavior when given a filename.

Fixes #60 