### PR TITLE
Return a Pathname from the file helper

### DIFF
--- a/lib/ammeter/rspec/generator/example/generator_example_group.rb
+++ b/lib/ammeter/rspec/generator/example/generator_example_group.rb
@@ -74,7 +74,7 @@ module Ammeter
         end
 
         def file relative
-          File.expand_path(relative, destination_root)
+          Pathname.new(File.expand_path(relative, destination_root))
         end
         def migration_file relative
           file_path = file(relative)

--- a/spec/ammeter/rspec/generator/example/generator_example_group_spec.rb
+++ b/spec/ammeter/rspec/generator/example/generator_example_group_spec.rb
@@ -43,7 +43,7 @@ module Ammeter::RSpec::Rails
           FileUtils.mkdir path_to_gem_root_tmp
         end
         it 'should use destination to find relative root file' do
-          expect(group.file('app/model/post.rb')).to eq "#{path_to_gem_root_tmp}/app/model/post.rb"
+          expect(group.file('app/model/post.rb').to_path).to eq "#{path_to_gem_root_tmp}/app/model/post.rb"
         end
 
         describe 'migrations' do


### PR DESCRIPTION
Otherwise, warnings were printed when the return value of the `file` helper was used with the `exist` matcher:
```ruby
subject { file('posts_spec.rb') }
it { is_expected.to exist }
```

Follow-up to #68

Other CI failures are unrelated, also present on `main` (see [this PR](https://github.com/alexrothenberg/ammeter/pull/69)).